### PR TITLE
cleaning up redundant package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function (grunt) {
     babel: {
        options: {
          sourceMap: true,
-         presets: ['es2015']
+         presets: ['env']
        },
        lib: {
         files: {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "babel-core": "^6.26.0",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-preset-env": "^1.6.1",
-    "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.24.1",
     "chai": "^4.0.2",
     "chai-as-promised": "^7.0.0",


### PR DESCRIPTION
This should upgrade the babel-presets-es2015 package to babel-presets-env

package-lock.json is NOT modified as I'm not using npm 5+ yet. so feel free to drop and redo yourself. I don't need this to be merged as-is.