### PR TITLE
Add protocol to url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-fulfiller-identity",
-  "version": "0.3.0",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-fulfiller-identity",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Thin client library for Cimpress' Fulfiller Identity service",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/fulfiller_identity_client.js
+++ b/src/fulfiller_identity_client.js
@@ -22,7 +22,7 @@ class FulfillerIdentityClient {
     } else {
       throw new Error("The authorization should be either a string, a function that returns a string, or a function that returns a Promise");
     }
-    this.baseUrl = (options && options.url) ? options.url : "fulfilleridentity.trdlnk.cimpress.io";
+    this.baseUrl = (options && options.url) ? options.url : "https://fulfilleridentity.trdlnk.cimpress.io";
     this.xrayPRoxy = new XRayProxy(this.authorizer, awsXRay);
   }
 


### PR DESCRIPTION
If the protocol of the url is not specified, javascript is adding the server path.

e.g.

http://localhost:3000/fulfilleridentity.trdlnk.cimpress.io/v1/fulfillers 