### PR TITLE
Return error name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-fulfiller-identity",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-fulfiller-identity",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Thin client library for Cimpress' Fulfiller Identity service",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/errors/fulfiller_not_found_error.js
+++ b/src/errors/fulfiller_not_found_error.js
@@ -1,7 +1,7 @@
 class FulfillerNotFoundError extends Error {
     constructor(...args) {
-        super(...args)
-        this.name = 'FulfillerNotFoundError'
+        super(...args);
+        this.name = 'FulfillerNotFoundError';
     }
 }
 

--- a/src/errors/fulfiller_not_found_error.js
+++ b/src/errors/fulfiller_not_found_error.js
@@ -1,5 +1,9 @@
 class FulfillerNotFoundError extends Error {
-
+    constructor(...args) {
+        super(...args)
+        this.name = 'FulfillerNotFoundError'
+    }
 }
+
 
 module.exports = FulfillerNotFoundError;


### PR DESCRIPTION
When the class FulfillerNotFoundError is babelfied we are losing the class name. This is needed to act in consequence of the error when using the client.